### PR TITLE
Fix error code returned from successful run

### DIFF
--- a/shared/runlast.sh
+++ b/shared/runlast.sh
@@ -346,4 +346,4 @@ case "$1" in
         ;;
 esac
 
-[[ -e $TEMP_LOG_PATHFILE ]] && rm -f "$TEMP_LOG_PATHFILE"
+[[ -e $TEMP_LOG_PATHFILE ]] && rm -f "$TEMP_LOG_PATHFILE" || echo -n ''

--- a/shared/runlast.sh
+++ b/shared/runlast.sh
@@ -346,4 +346,6 @@ case "$1" in
         ;;
 esac
 
-[[ -e $TEMP_LOG_PATHFILE ]] && rm -f "$TEMP_LOG_PATHFILE" || echo -n ''
+[[ -e $TEMP_LOG_PATHFILE ]] && rm -f "$TEMP_LOG_PATHFILE"
+
+exit 0


### PR DESCRIPTION
RunLast is failing in the last line and returning exit code 1,
because the tmp file does not exist:

```
+ local last_op_line_num=146
+ head -n146 /share/CACHEDEV1_DATA/.qpkg/RunLast/RunLast.log
+ mv /share/CACHEDEV1_DATA/.qpkg/RunLast/RunLast.log.tmp /share/CACHEDEV1_DATA/.qpkg/RunLast/RunLast.log
+ [[ -e /share/CACHEDEV1_DATA/.qpkg/RunLast/RunLast.log.tmp ]]
```